### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@ source "https://rubygems.org"
 
 gem "rest-client"
 
-#for development only
-gem "rack"
-gem "thin"
-gem "nokogiri"
-gem "yard"
-gem "upton", :path => "."
-gem "rake"
-gem "redcarpet"
+group :development do
+  gem "rack"
+  gem "thin"
+  gem "nokogiri"
+  gem "yard"
+  gem "upton", :path => "."
+  gem "rake"
+  gem "redcarpet"
+end
 


### PR DESCRIPTION
Bundler has a built in way for delineating gems for development. This way you can `bundle install` with a `--without development` flag to skip that.
