### PR TITLE
Implement @pagination_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `get_instance` and `get_index` methods use a protected method `get_page(url)
 
 Upton also sleeps (by default) 30 seconds between non-stashed requests, to reduce load on the server you're scraping. This is configurable with the `@sleep_time_between_requests` option.
 
-Upton can handle pagination too. Scraping paginated index pages that use a query string parameter to track the current page (e.g. `/search?q=test&page=2`) is possible by setting `@paginated` to true. Use `@pagination_param` to set the query string parameter used to specify the current page (the default value is `page`). Uses @pagination_max_pages to specify the number of pages to scrape (the default is two pages) See the Examples section below.
+Upton can handle pagination too. Scraping paginated index pages that use a query string parameter to track the current page (e.g. `/search?q=test&page=2`) is possible by setting `@paginated` to true. Use `@pagination_param` to set the query string parameter used to specify the current page (the default value is `page`). Use `@pagination_max_pages` to specify the number of pages to scrape (the default is two pages). You can also set @pagination_interval` if you want to increment pages by a number other than 1 (i.e. if the first page is 1 and lists instances 1 through 20, the second page is 21 and lists instances 21-41, etc.) See the Examples section below.
 
 To handle non-standard pagination, you can override the `next_index_page_url` and `next_instance_page_url` methods; Upton will get each page's URL returned by these functions and return their contents.
 

--- a/lib/upton.rb
+++ b/lib/upton.rb
@@ -35,7 +35,8 @@ module Upton
     EMPTY_STRING = ''
 
     attr_accessor :verbose, :debug, :index_debug, :sleep_time_between_requests, :stash_folder, :url_array,
-      :paginated, :pagination_param, :pagination_max_pages, :pagination_start_index, :readable_filenames
+      :paginated, :pagination_param, :pagination_max_pages, :pagination_start_index, :readable_filenames,
+      :pagination_interval
 
     ##
     # This is the main user-facing method for a basic scraper.
@@ -101,6 +102,8 @@ module Upton
       @pagination_max_pages = 2
       # Default starting number for pagination (second page is this plus 1).
       @pagination_start_index = 1
+      # Default value to increment page number by
+      @pagination_interval = 1
  
       # Folder name for stashes, if you want them to be stored somewhere else,
       # e.g. under /tmp.
@@ -260,7 +263,7 @@ module Upton
     # comes from an API.
     ##
     def get_index
-      index_pages = get_index_pages(@index_url, @pagination_start_index).map{|page| parse_index(page, @index_selector) }.flatten
+      index_pages = get_index_pages(@index_url, @pagination_start_index, @pagination_interval).map{|page| parse_index(page, @index_selector) }.flatten
     end
 
     # TODO: Not sure the best way to handle this
@@ -288,11 +291,11 @@ module Upton
     # Returns the concatenated output of each member of a paginated index,
     # e.g. a site listing links with 2+ pages.
     ##
-    def get_index_pages(url, pagination_index, options={})
+    def get_index_pages(url, pagination_index, pagination_interval, options={})
       resps = [self.get_page(url, @index_debug, options)]
       prev_url = url
       while !resps.last.empty?
-        pagination_index += 1
+        pagination_index += pagination_interval
         next_url = self.next_index_page_url(url, pagination_index)
         next_url = resolve_url(next_url, url)
         break if next_url == prev_url || next_url.empty?


### PR DESCRIPTION
I'm currently working on a scraping a website (sorry, can't share it at the moment) that handles pagination more like `offset` in SQL than using page numbers. Each page displays 20 instances. The first page is `start=1`, the second page is `start=21`, the third is `start=41`, etc. This pull request allows the user to ability to specify a number other than 1 that should be added to `pagination_index` to get the next page. The default value of `pagination_interval` is 1. For this site, setting up Upton to handle pagination would like this:

```
scraper.paginated = true
scraper.pagination_param = 'start'
scraper.pagination_interval = 20
scraper.pagination_max_pages = 12001
```
